### PR TITLE
Fix issue with integer Munin internal label

### DIFF
--- a/apache_error_rate
+++ b/apache_error_rate
@@ -18,7 +18,7 @@ if [ "$1" = "config" ]; then
 
 	for code in $mystatuscodes
 		do
-		echo "${code}.label ${code} Errors"
+		echo "error_${code}.label ${code} Errors"
 	done
 
         echo 'graph_info The number of apache errors in logs'
@@ -27,7 +27,7 @@ fi
 
         for code in $mystatuscodes
                 do
-		echo -n "${code}.value "
+		echo -n "error_${code}.value "
 		tail -${myloglines} ${myaccesslog} | awk '{print $9 }' | grep -c "${code}"
         done
 


### PR DESCRIPTION
Internal Munin label with integer name create a bug :
- 400 > _00
- 401 > _01
- 403 > _03
  ...
- 503 > _03

403 errors was reported as 503 ... Easiest way to avoid that is starting the internal name with letter, as I do here
