### PR TITLE
fix(parsing): filter garbage log lines

### DIFF
--- a/apache_error_rate
+++ b/apache_error_rate
@@ -16,10 +16,10 @@ if [ "$1" = "config" ]; then
         echo 'graph_vlabel rate'
         echo 'graph_scale no'
 
-	for code in $mystatuscodes
-		do
-		echo "error_${code}.label ${code} Errors"
-	done
+        for code in $mystatuscodes
+                do
+                echo "error_${code}.label ${code} Errors"
+        done
 
         echo 'graph_info The number of apache errors in logs'
         exit 0
@@ -27,8 +27,8 @@ fi
 
         for code in $mystatuscodes
                 do
-		echo -n "error_${code}.value "
-		tail -${myloglines} ${myaccesslog} | awk '{print $9 }' | grep -c "${code}"
+                echo -n "error_${code}.value "
+                tail -${myloglines} ${myaccesslog} | grep -o 'HTTP/.\.." [0-9]\{3\} ' | grep -c " ${code} "
         done
 
 exit 0

--- a/apache_error_rate
+++ b/apache_error_rate
@@ -3,9 +3,9 @@
 # If run with the "config"-parameter, give out information on how the
 # graphs should look.
 
-mystatuscodes="400 401 403 404 500 503 504"
-myloglines="10000"
-myaccesslog="/var/log/apache2/access.log"
+mystatuscodes="${mystatuscodes:-400 401 403 404 500 503 504}"
+myloglines="${myloglines:-10000}"
+myaccesslog="${myaccesslog:-/var/log/apache2/access.log}"
 
 if [ "$1" = "config" ]; then
 


### PR DESCRIPTION
I noticed we have garbage lines in our logs, for example HTTP queries without a HTTP verb (many thanks, bots).

Also this change allows not to have to rely on column position.
